### PR TITLE
Add Google Analytics Tracking

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,7 +6,15 @@ module.exports = {
   },
   plugins: [
     {
-      resolve: 'gatsby-plugin-web-font-loader',
+      resolve: `gatsby-plugin-google-analytics`,
+      options: {
+        trackingId: "UA-1224199-64",
+        head: true,
+        anonymize: true,
+      }
+    },
+    {
+      resolve: `gatsby-plugin-web-font-loader`,
       options: {
         google: {
           families: ['Poppins:400', 'Poppins:700', 'IBM Plex Mono']

--- a/package-lock.json
+++ b/package-lock.json
@@ -6894,6 +6894,14 @@
         "lodash": "^4.17.11"
       }
     },
+    "gatsby-plugin-google-analytics": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.0.19.tgz",
+      "integrity": "sha512-Db1nOpzS1Nq52E0tFfgF2uCPCnWEtJbUMKLX1RU5Hfki8BoPHpZUHrcd5NtT3KQuVa7Ekps+3uJVziK+Yj5n+A==",
+      "requires": {
+        "@babel/runtime": "^7.0.0"
+      }
+    },
     "gatsby-plugin-manifest": {
       "version": "2.0.29",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.0.29.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "gatsby": "^2.3.25",
     "gatsby-image": "^2.0.39",
     "gatsby-plugin-favicon": "^3.1.6",
+    "gatsby-plugin-google-analytics": "^2.0.19",
     "gatsby-plugin-manifest": "^2.0.29",
     "gatsby-plugin-offline": "^2.0.25",
     "gatsby-plugin-react-helmet": "^3.0.12",

--- a/src/components/callToAction.js
+++ b/src/components/callToAction.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { OutboundLink } from "gatsby-plugin-google-analytics"
 import callToActionStyles from "./callToAction.module.css"
 
 const CallToAction = () => (
@@ -11,8 +12,10 @@ const CallToAction = () => (
       You can keep science-ing on your mobile device or at home with
       <a className="peach-link" href="https://www.galaxyzoo.org">Galaxy Zoo</a>, a project from Zooniverse. Check it out!
     </span>
-    <div className={callToActionStyles.buttons}>
-      <button className="solid-button"><a href='https://www.galaxyzoo.org'>Galaxyzoo.org</a></button>
+    <div>
+      <button className="solid-button">
+        <OutboundLink href='https://www.galaxyzoo.org'>Galaxyzoo.org</OutboundLink>
+      </button>
     </div>
   </div>
 )

--- a/src/components/callToAction.js
+++ b/src/components/callToAction.js
@@ -10,7 +10,8 @@ const CallToAction = () => (
     </h2>
     <span>
       You can keep science-ing on your mobile device or at home with
-      <a className="peach-link" href="https://www.galaxyzoo.org">Galaxy Zoo</a>, a project from Zooniverse. Check it out!
+      <OutboundLink className="peach-link" href="https://www.galaxyzoo.org">Galaxy Zoo</OutboundLink>
+      , a project from Zooniverse. Check it out!
     </span>
     <div>
       <button className="solid-button">

--- a/src/components/data.js
+++ b/src/components/data.js
@@ -8,7 +8,7 @@ const Data = () => (
     <span className='descriptor'>
       People just like you have been classifying galaxies from U!Scientist at
       the Adler as well as online on
-      <a href="https://www.galaxyzoo.org" className="peach-link">Galaxy Zoo</a>
+      <OutboundLink href="https://www.galaxyzoo.org" className="peach-link">Galaxy Zoo</OutboundLink>
     </span>
     <div className={dataStyles.stats}>
       <div>

--- a/src/components/data.js
+++ b/src/components/data.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { OutboundLink } from "gatsby-plugin-google-analytics"
 import dataStyles from "./data.module.css"
 
 const Data = () => (
@@ -24,7 +25,7 @@ const Data = () => (
     </div>
     <div className={dataStyles.buttons}>
       <button className='solid-button'>
-        <a href='https://www.galaxyzoo.org'>galaxyzoo.org</a>
+        <OutboundLink href='https://www.galaxyzoo.org'>galaxyzoo.org</OutboundLink>
       </button>
     </div>
   </div>

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -11,8 +11,15 @@ const Layout = ({ data }) => {
       render={data => (
         <div className={footerStyles.footer}>
           <Img fixed={data.file.childImageSharp.fixed} />
-          <span>U!Scientist is made possible by a grant from the national science foundation.</span>
-          <span>The Zoonivese is a collaboration between the Adler Planetarium, The University of Oxford, The University of Minnesota, and the broader Citizen Science Alliance.</span>
+          <span>
+            This material is based upon work supported by the national science
+            foundation under grant #AISL-1713425
+          </span>
+          <span>
+            The Zoonivese is a collaboration between the Adler Planetarium, The
+            University of Oxford, The University of Minnesota, and the broader
+            Citizen Science Alliance.
+          </span>
           <OutboundLink href="https://zooniverse.org">zooniverse.org</OutboundLink>
         </div>
       )}

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -10,7 +10,11 @@ const Layout = ({ data }) => {
       query={query}
       render={data => (
         <div className={footerStyles.footer}>
-          <Img fixed={data.file.childImageSharp.fixed} />
+          <div className={footerStyles.logos}>
+            <Img fixed={data.nsf.childImageSharp.fixed} />
+            <div className={footerStyles.separator}/>
+            <Img fixed={data.zooniverse.childImageSharp.fixed} />
+          </div>
           <span>
             This material is based upon work supported by the national science
             foundation under grant #AISL-1713425
@@ -29,9 +33,16 @@ const Layout = ({ data }) => {
 
 export const query = graphql`
   query {
-    file(relativePath: { eq: "zooniverse-logo.png" }) {
+    zooniverse: file(relativePath: { eq: "zooniverse-logo.png" }) {
       childImageSharp {
-        fixed(width: 200) {
+        fixed(height: 18) {
+          ...GatsbyImageSharpFixed
+        }
+      }
+    }
+    nsf: file(relativePath: { eq: "nsf.png" }) {
+      childImageSharp {
+        fixed(height: 35) {
           ...GatsbyImageSharpFixed
         }
       }

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,7 +1,8 @@
 import React from "react"
-import footerStyles from "./footer.module.css"
 import { StaticQuery, graphql } from "gatsby"
 import Img from "gatsby-image"
+import { OutboundLink } from "gatsby-plugin-google-analytics"
+import footerStyles from "./footer.module.css"
 
 const Layout = ({ data }) => {
   return (
@@ -12,7 +13,7 @@ const Layout = ({ data }) => {
           <Img fixed={data.file.childImageSharp.fixed} />
           <span>U!Scientist is made possible by a grant from the national science foundation.</span>
           <span>The Zoonivese is a collaboration between the Adler Planetarium, The University of Oxford, The University of Minnesota, and the broader Citizen Science Alliance.</span>
-          <a href="https://zooniverse.org">zooniverse.org</a>
+          <OutboundLink href="https://zooniverse.org">zooniverse.org</OutboundLink>
         </div>
       )}
     />

--- a/src/components/footer.module.css
+++ b/src/components/footer.module.css
@@ -1,5 +1,5 @@
 .footer {
-  background: white;
+  background: #EFF2F5;
   height: auto;
   padding: 2rem 4rem;
   text-align: center;
@@ -18,4 +18,24 @@
   margin: 0.75rem 0;
   text-align: center;
   text-transform: uppercase;
+}
+
+.logos {
+  display: inline-flex;
+  margin: 0 auto;
+}
+
+.logos div {
+  margin: auto 0.5rem;
+}
+
+.separator {
+  border-left: 1px solid black;
+  height: 2rem;
+}
+
+@media only screen and (max-width: 768px) {
+  .footer {
+    padding: 2rem;
+  }
 }

--- a/src/components/general.js
+++ b/src/components/general.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { OutboundLink } from "gatsby-plugin-google-analytics"
 import generalStyles from "./general.module.css"
 import icons from "../images/icons.png";
 import mobileIcons from "../images/mobile-icons.png";
@@ -26,7 +27,7 @@ const General = () => (
       <img alt="Discipline Icons" className="icons-image-mobile" src={mobileIcons} />
     </div>
     <button className='hollow-button'>
-      <a href='https://www.zooniverse.org'>zooniverse.org</a>
+      <OutboundLink href='https://www.zooniverse.org'>zooniverse.org</OutboundLink>
     </button>
   </div>
 );

--- a/src/components/recent.js
+++ b/src/components/recent.js
@@ -10,13 +10,13 @@ const Recent = () => (
       <span className='descriptor'>
         Check out some of the galaxies that have been classified both on
         U!Scientist at the Adler Planetarium and online on
-        <a className="peach-link" href="https://www.galaxyzoo.org">Galaxy Zoo.</a>
+        <OutboundLink className="peach-link" href="https://www.galaxyzoo.org">Galaxy Zoo.</OutboundLink>
       </span>
       <div className={recentStyles.subjects}>
         {placeholder.map((image, i) =>
             <div key={i} className={recentStyles.subject}>
               <div />
-              <a href="https://www.zooniverse.org">{image}</a>
+              <OutboundLink href="https://www.zooniverse.org">{image}</OutboundLink>
             </div>
         )}
       </div>

--- a/src/components/recent.js
+++ b/src/components/recent.js
@@ -1,5 +1,6 @@
 import React from "react"
 import recentStyles from "./recent.module.css"
+import { OutboundLink } from "gatsby-plugin-google-analytics"
 
 const placeholder = ["SBJ.26440667", "SBJ.26440667", "SBJ.26440667"];
 
@@ -20,7 +21,7 @@ const Recent = () => (
         )}
       </div>
       <button className='hollow-button'>
-        <a href='https://www.galaxyzoo.org'>more recent galaxies</a>
+        <OutboundLink href='https://www.galaxyzoo.org'>more recent galaxies</OutboundLink>
       </button>
     </div>
 );


### PR DESCRIPTION
Woah! Adding Google Analytics was so easy for this page. I used a Gatsby plugin to get things squared away. The only thing to keep in mind is that you have to run a production build (`gatsby build && gatsby serve`) to test this out locally. 

There is a "Touchtable Website" property set up to track events on the intermediate page. This currently includes page visits and clicks to outbound sites.